### PR TITLE
ci: add  test `GitHub Actions` for test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,3 @@ jobs:
           pip install pytest
       - name: Run Test
         run: pytest tests/
-i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - [main, ci]
+      - ci
 
 jobs:
   lint_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get install ffmpeg
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
           pip install .
           pip install pytest
       - name: Run Test
-        run: pytest tests/
+        run: pytest test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - [main, ci]
+
+jobs:
+  lint_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+      - name: Run Test
+        run: pytest tests/
+i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - ci
+      - main
 
 jobs:
   lint_and_test:

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+log/

--- a/README.md
+++ b/README.md
@@ -185,4 +185,5 @@ autocut
 1. commit 信息用英文描述清楚你做了哪些修改即可，小写字母开头。
 2. 最好可以保证一次的 commit 涉及的修改比较小，可以简短地描述清楚，这样也方便之后有修改时的查找。
 3. PR 的时候 title 简述有哪些修改， contents 可以具体写下修改内容。
+4. run test `pip install pytest` then `pytest test`
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ requirements = [
     'srt',
     'moviepy',
     'opencc-python-reimplemented',
+    'torchaudio',
+    'parameterized',
     'whisper @ git+https://github.com/openai/whisper.git'
 ]
 

--- a/test/test_cut.py
+++ b/test/test_cut.py
@@ -5,7 +5,7 @@ import unittest
 from parameterized import parameterized, param
 
 from autocut.cut import Cutter
-from test.config import TestArgs, TEST_VIDEO_PATH, TEST_VIDEO_FILE_SIMPLE, TEST_CONTENT_PATH
+from config import TestArgs, TEST_VIDEO_PATH, TEST_VIDEO_FILE_SIMPLE, TEST_CONTENT_PATH
 
 
 class TestCut(unittest.TestCase):

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -5,7 +5,7 @@ import unittest
 from parameterized import parameterized, param
 
 from autocut.utils import MD
-from test.config import TEST_VIDEO_FILE, TestArgs, TEST_VIDEO_FILE_SIMPLE, TEST_VIDEO_FILE_LANG, TEST_VIDEO_PATH
+from config import TEST_VIDEO_FILE, TestArgs, TEST_VIDEO_FILE_SIMPLE, TEST_VIDEO_FILE_LANG, TEST_VIDEO_PATH
 from autocut.transcribe import Transcribe
 
 


### PR DESCRIPTION
feat for: #41

passed ci see: https://github.com/yihong0618/autocut/actions/runs/3485766340

1. 看到 README 上写的保留 commit 我没有 rebase, 如果有需要可以 rebase 到一个 commit 
2. 目前不支持 3.11 torchaudio 不支持 3.11 目前，之后支持会加上 see https://github.com/yihong0618/autocut/actions/runs/3485734452/jobs/5831524322
3. 目前 linux 没问题，MacOS M1 会报错，我暂时保留了这个测试，稍后研究下
4. 目前 ci 没有支持 lint, @mli 不知道考虑 `black` 么，如果考虑我可以加上



报错信息

 test/test_transcribe.py::TestTranscribe::test_vad_transcribe_0_test001_mp4 - OSError: dlopen(/opt/homebrew/lib/python3.10/site-packages/torchaudio/lib/libtorchaudio.so, 0x0006): Symbol not found: (__ZN2at27getStepCallbacksUnless.