### PR TITLE
Add all languages supported by whisper

### DIFF
--- a/autocut/main.py
+++ b/autocut/main.py
@@ -50,7 +50,17 @@ def main():
         "--lang",
         type=str,
         default="zh",
-        choices=["zh", "en"],
+        choices=[
+            "zh", "en", "Afrikaans", "Arabic", "Armenian", "Azerbaijani", "Belarusian",
+            "Bosnian", "Bulgarian", "Catalan", "Croatian", "Czech", "Danish", "Dutch",
+            "Estonian", "Finnish", "French", "Galician", "German", "Greek", "Hebrew",
+            "Hindi", "Hungarian", "Icelandic", "Indonesian", "Italian", "Japanese",
+            "Kannada", "Kazakh", "Korean", "Latvian", "Lithuanian", "Macedonian",
+            "Malay", "Marathi", "Maori", "Nepali", "Norwegian", "Persian", "Polish",
+            "Portuguese", "Romanian", "Russian", "Serbian", "Slovak", "Slovenian",
+            "Spanish", "Swahili", "Swedish", "Tagalog", "Tamil", "Thai", "Turkish",
+            "Ukrainian", "Urdu", "Vietnamese", "Welsh"
+            ],
         help="The output language of transcription",
     )
     parser.add_argument(


### PR DESCRIPTION
Dear Mu Li and other contributors,

I found there is no Japanese when I tried to make Japanese speech-to-text. So I added all supported languages, and I successfully speech-to-text my Japanese videos.