### PR TITLE
安装的包名与元数据不一致错误

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
     "opencc-python-reimplemented",
     "torchaudio",
     "parameterized",
-    "whisper @ git+https://github.com/openai/whisper.git",
+    "openai-whisper @ git+https://github.com/openai/whisper.git",
     "tqdm",
 ]
 


### PR DESCRIPTION
解决安装时出现的 inconsistent name: expected 'whisper', but metadata has 'openai-whisper'