### PR TITLE
使用 whisper 指定版本

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
     "opencc-python-reimplemented",
     "torchaudio",
     "parameterized",
-    "openai-whisper",
+    "openai-whisper==20230314",
     "tqdm",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
     "opencc-python-reimplemented",
     "torchaudio",
     "parameterized",
-    "whisper @ git+https://github.com/openai/whisper.git",
+    "openai-whisper",
     "tqdm",
 ]
 


### PR DESCRIPTION
Python 3.9.5 环境下 , 
在 autocut 工程里 `pip install .` 时, 安装最新的 whisper 会报错.  修改 setup.py 里安装包为指定版本.

```
ERROR: Could not find a version that satisfies the requirement whisper (unavailable) (from autocut) (from versions: 0.9.5, 0.9.6, 0.9.7, 0.9.8, 0.9.9, 0.9.10, 0.9.11, 0.9.12, 0.9.13, 0.9.14, 0.9.15, 0.9.16, 1.0.0, 1.0.1, 1.0.2, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, 1.1.7, 1.1.8, 1.1.9, 1.1.10)
ERROR: No matching distribution found for whisper (unavailable)
```
 